### PR TITLE
Improve tests for error handling

### DIFF
--- a/t/93_error_handling.t
+++ b/t/93_error_handling.t
@@ -45,6 +45,10 @@ global_tracer_cmp_easy(
                 'message'               => re(qr/Method Die/),
             },
         },
+        {
+            operation_name          => 'cgi_application_run',
+            level                   => 1,
+        },
     ], 'CGI::App [WithErrorBase/run_mode_die], dies "Method Die" at [method_die]'
 );
 
@@ -67,11 +71,12 @@ global_tracer_cmp_easy(
             },      
         },
         {
-            operation_name => 'level_one',
-            tags           => {
-                'error' => 1,
-                'message' => re(qr/Inside Die/),
+            operation_name          => 'cgi_application_run',
+            level                   => 1,
+        },
+        {
             operation_name          => 'level_one',
+            level                   => 2,
             tags                    => {
                 'error'                 => 1,
                 'message'               => re(qr/Inside Die/),
@@ -96,6 +101,10 @@ global_tracer_cmp_easy(
                 'run_mode'              => 'run_mode_xxx',
                 'message'               => re(qr/No such run mode/),
             },
+        },
+        {
+            operation_name          => 'cgi_application_run',
+            level                   => 1,
         },
     ], 'CGI::App [WithErrorBase/run_mode_xxx] invalid'
 );
@@ -134,6 +143,10 @@ global_tracer_cmp_easy(
                 'run_method'            => 'method_die',
             },
         },
+        {
+            operation_name          => 'cgi_application_run',
+            level                   => 1,
+        },
     ], 'CGI::App [WithErrorMode/run_mode_die], dies "Method Die" at [method_die]'
 );
 
@@ -155,7 +168,12 @@ global_tracer_cmp_easy(
             },
         },
         {
+            operation_name          => 'cgi_application_run',
+            level                   => 1,
+        },
+        {
             operation_name          => 'level_one',
+            level                   => 2,
             tags                    => {
                 'error'                 => 1,
                 'message'               => re(qr/Inside Die/),

--- a/t/93_error_handling.t
+++ b/t/93_error_handling.t
@@ -3,7 +3,11 @@ use Test::MockObject;
 use Test::OpenTracing::Integration;
 use Test::WWW::Mechanize::CGIApp;
 
-my $mech = Test::WWW::Mechanize::CGIApp->new(app => 'MyTest::WithErrorBase');
+my $mech = Test::WWW::Mechanize::CGIApp->new();
+
+lives_ok {
+    $mech->app('MyTest::WithErrorBase');
+} "Set Test::WWW::Mechanize app to 'MyTest::WithErrorBase'";
 
 eval { $mech->get('https://test.tst/test.cgi?rm=run_mode_die') };
 global_tracer_cmp_easy(
@@ -99,7 +103,9 @@ global_tracer_cmp_easy(
     ], 'CGI::App [WithErrorBase/run_mode_xxx] invalid'
 );
 
-$mech = Test::WWW::Mechanize::CGIApp->new(app => 'MyTest::WithErrorMode');
+lives_ok {
+    $mech->app('MyTest::WithErrorMode');
+} "Set Test::WWW::Mechanize app to 'MyTest::WithErrorMode'";
 
 $mech->get('https://test.tst/test.cgi?rm=run_mode_die');
 global_tracer_cmp_easy(

--- a/t/93_error_handling.t
+++ b/t/93_error_handling.t
@@ -48,6 +48,10 @@ global_tracer_cmp_easy(
         {
             operation_name          => 'cgi_application_run',
             level                   => 1,
+            tags                    => {
+                'error'                 => 1,
+                'message'               => re(qr/Method Die/),
+            },
         },
     ], 'CGI::App [WithErrorBase/run_mode_die], dies "Method Die" at [method_die]'
 );
@@ -73,6 +77,10 @@ global_tracer_cmp_easy(
         {
             operation_name          => 'cgi_application_run',
             level                   => 1,
+            tags                    => {
+                'error'                 => 1,
+                'message'               => re(qr/Inside Die/),
+            },
         },
         {
             operation_name          => 'level_one',
@@ -105,6 +113,10 @@ global_tracer_cmp_easy(
         {
             operation_name          => 'cgi_application_run',
             level                   => 1,
+            tags                    => {
+                'error'                 => 1,
+                'message'               => re(qr/No such run mode/),
+            },
         },
     ], 'CGI::App [WithErrorBase/run_mode_xxx] invalid'
 );
@@ -146,6 +158,7 @@ global_tracer_cmp_easy(
         {
             operation_name          => 'cgi_application_run',
             level                   => 1,
+            tags                    => {},
         },
     ], 'CGI::App [WithErrorMode/run_mode_die], dies "Method Die" at [method_die]'
 );
@@ -170,6 +183,7 @@ global_tracer_cmp_easy(
         {
             operation_name          => 'cgi_application_run',
             level                   => 1,
+            tags                    => {},
         },
         {
             operation_name          => 'level_one',

--- a/t/93_error_handling.t
+++ b/t/93_error_handling.t
@@ -15,6 +15,34 @@ lives_ok {
 
 
 
+$mech->get('https://test.tst/test.cgi?rm=run_mode_204');
+
+global_tracer_cmp_easy(
+    [
+        {
+            operation_name          => 'cgi_application_request',
+            level                   => 0,
+            tags                    => {
+                'component'             => 'CGI::Application',
+                'http.method'           => 'GET',
+                'http.url'              => 'https://test.tst/test.cgi',
+                'http.query.rm'         => 'run_mode_204',
+                'http.status_code'      => 204,
+                'http.status_message'   => 'No Content',
+                'run_mode'              => 'run_mode_204',
+                'run_method'            => 'method_204',
+            },
+        },
+        {
+            operation_name          => 'cgi_application_run',
+            level                   => 1,
+            tags                    => { },
+        },
+    ], 'CGI::App [WithErrorBase/run_mode_204], Returns "No Content" at [method_204]'
+);
+
+
+
 eval { $mech->get('https://test.tst/test.cgi?rm=run_mode_die') };
 
 global_tracer_cmp_easy(
@@ -124,6 +152,34 @@ lives_ok {
 
 
 
+$mech->get('https://test.tst/test.cgi?rm=run_mode_204');
+
+global_tracer_cmp_easy(
+    [
+        {
+            operation_name          => 'cgi_application_request',
+            level                   => 0,
+            tags                    => {
+                'component'             => 'CGI::Application',
+                'http.method'           => 'GET',
+                'http.url'              => 'https://test.tst/test.cgi',
+                'http.query.rm'         => 'run_mode_204',
+                'http.status_code'      => 204,
+                'http.status_message'   => 'No Content',
+                'run_mode'              => 'run_mode_204',
+                'run_method'            => 'method_204',
+            },
+        },
+        {
+            operation_name          => 'cgi_application_run',
+            level                   => 1,
+            tags                    => { },
+        },
+    ], 'CGI::App [WithErrorMode/run_mode_204], Returns "No Content" at [method_204]'
+);
+
+
+
 $mech->get('https://test.tst/test.cgi?rm=run_mode_die');
 
 global_tracer_cmp_easy(
@@ -199,6 +255,7 @@ use OpenTracing::GlobalTracer qw/$TRACER/;
 sub run_modes {
     run_mode_die => 'method_die',
     run_mode_one => 'method_one',
+    run_mode_204 => 'method_204',
 }
 
 sub method_die { die 'Something wrong within "Method Die"' }
@@ -207,6 +264,8 @@ sub method_one {
     my $scope = $TRACER->start_active_span('level_one');
     inside_die();
 }
+
+sub method_204 { $_[0]->header_add(-status => '204') }
 
 sub inside_die { die 'Something wrong within "Inside Die"' }
 

--- a/t/93_error_handling.t
+++ b/t/93_error_handling.t
@@ -4,28 +4,30 @@ use Test::OpenTracing::Integration;
 use Test::WWW::Mechanize::CGIApp;
 
 {
-    package MyTest::DyingApp;
+    package MyTest::WithErrorBase;
     use base 'CGI::Application';
 
     use CGI::Application::Plugin::OpenTracing qw/Test/;
     use OpenTracing::GlobalTracer qw/$TRACER/;
 
     sub run_modes {
-        run_fail  => 'broken_method',
-        run_break => 'broken_span',
+        run_mode_die => 'method_die',
+        run_mode_one => 'method_one',
     }
 
-    sub broken_method { die 'Something wrong' }
+    sub method_die { die 'Something wrong within "Method Die"' }
 
-    sub broken_span {
-        my $scope = $TRACER->start_active_span('broken');
-        broken_method();
+    sub method_one {
+        my $scope = $TRACER->start_active_span('level_one');
+        inside_die();
     }
+
+    sub inside_die { die 'Something wrong within "Inside Die"' }
 }
 
-my $mech = Test::WWW::Mechanize::CGIApp->new(app => 'MyTest::DyingApp');
+my $mech = Test::WWW::Mechanize::CGIApp->new(app => 'MyTest::WithErrorBase');
 
-eval { $mech->get('https://test.tst/test.cgi?rm=run_fail') };
+eval { $mech->get('https://test.tst/test.cgi?rm=run_mode_die') };
 global_tracer_cmp_easy(
     [
         {
@@ -35,18 +37,18 @@ global_tracer_cmp_easy(
                 'component'        => 'CGI::Application',
                 'http.method'      => 'GET',
                 'http.url'         => 'https://test.tst/test.cgi',
-                'http.query.rm'    => 'run_fail',
+                'http.query.rm'    => 'run_mode_die',
                 'http.status_code' => 500,
-                'run_mode'         => 'run_fail',
-                'run_method'       => 'broken_method',
+                'run_mode'         => 'run_mode_die',
+                'run_method'       => 'method_die',
                 'error'            => 1,
-                'message'          => re(qr/Something wrong/),
+                'message'          => re(qr/Method Die/),
             },
         },
-    ], 'run_method dies and no on_error handler is defined'
+    ], 'CGI::App [WithErrorBase/run_mode_die], dies "Method Die" at [method_die]'
 );
 
-eval { $mech->get('https://test.tst/test.cgi?rm=run_break') };
+eval { $mech->get('https://test.tst/test.cgi?rm=run_mode_one') };
 global_tracer_cmp_easy(
     [
         {
@@ -56,25 +58,25 @@ global_tracer_cmp_easy(
                 'component'        => 'CGI::Application',
                 'http.method'      => 'GET',
                 'http.url'         => 'https://test.tst/test.cgi',
-                'http.query.rm'    => 'run_break',
+                'http.query.rm'    => 'run_mode_one',
                 'http.status_code' => 500,
-                'run_mode'         => 'run_break',
-                'run_method'       => 'broken_span',
+                'run_mode'         => 'run_mode_one',
+                'run_method'       => 'method_one',
                 'error'            => 1,
-                'message'          => re(qr/Something wrong/),
+                'message'          => re(qr/Inside Die/),
             },
         },
         {
-            operation_name => 'broken',
+            operation_name => 'level_one',
             tags           => {
                 'error' => 1,
-                'message' => re(qr/Something wrong/),
+                'message' => re(qr/Inside Die/),
             },
         },
-    ], 'run_method with an embedded span dies'
+    ], 'CGI::App [WithErrorBase/run_mode_one], dies "Inside Die" at [level_one/inside_die]'
 );
 
-eval { $mech->get('https://test.tst/test.cgi?rm=nothinghere') };
+eval { $mech->get('https://test.tst/test.cgi?rm=run_mode_xxx') };
 global_tracer_cmp_easy(
     [
         {
@@ -84,19 +86,19 @@ global_tracer_cmp_easy(
                 'component'        => 'CGI::Application',
                 'http.method'      => 'GET',
                 'http.url'         => 'https://test.tst/test.cgi',
-                'http.query.rm'    => 'nothinghere',
+                'http.query.rm'    => 'run_mode_xxx',
                 'http.status_code' => 500,
                 'error'            => 1,
-                'run_mode'         => 'nothinghere',
+                'run_mode'         => 'run_mode_xxx',
                 'message'          => re(qr/No such run mode/),
             },
         },
-    ], 'invalid runmode selected'
+    ], 'CGI::App [WithErrorBase/run_mode_xxx] invalid'
 );
 
 {
-    package MyTest::SurvivingApp;
-    use base 'MyTest::DyingApp';
+    package MyTest::WithErrorMode;
+    use base 'MyTest::WithErrorBase';
 
     sub cgiapp_init { $_[0]->error_mode('show_error') }
 
@@ -109,9 +111,9 @@ global_tracer_cmp_easy(
     }
 }
 
-$mech = Test::WWW::Mechanize::CGIApp->new(app => 'MyTest::SurvivingApp');
+$mech = Test::WWW::Mechanize::CGIApp->new(app => 'MyTest::WithErrorMode');
 
-$mech->get('https://test.tst/test.cgi?rm=run_fail');
+$mech->get('https://test.tst/test.cgi?rm=run_mode_die');
 global_tracer_cmp_easy(
     [
         {
@@ -121,17 +123,17 @@ global_tracer_cmp_easy(
                 'component'           => 'CGI::Application',
                 'http.method'         => 'GET',
                 'http.url'            => 'https://test.tst/test.cgi',
-                'http.query.rm'       => 'run_fail',
+                'http.query.rm'       => 'run_mode_die',
                 'http.status_code'    => '402',
                 'http.status_message' => "Payment Required",
-                'run_mode'            => 'run_fail',
-                'run_method'          => 'broken_method',
+                'run_mode'            => 'run_mode_die',
+                'run_method'          => 'method_die',
             },
         },
-    ], 'run_method dies and an on_error handler is defined'
+    ], 'CGI::App [WithErrorMode/run_mode_die], dies "Method Die" at [method_die]'
 );
 
-$mech->get('https://test.tst/test.cgi?rm=run_break');
+$mech->get('https://test.tst/test.cgi?rm=run_mode_one');
 global_tracer_cmp_easy(
     [
         {
@@ -141,21 +143,21 @@ global_tracer_cmp_easy(
                 'component'           => 'CGI::Application',
                 'http.method'         => 'GET',
                 'http.url'            => 'https://test.tst/test.cgi',
-                'http.query.rm'       => 'run_break',
+                'http.query.rm'       => 'run_mode_one',
                 'http.status_code'    => '402',
                 'http.status_message' => "Payment Required",
-                'run_mode'            => 'run_break',
-                'run_method'          => 'broken_span',
+                'run_mode'            => 'run_mode_one',
+                'run_method'          => 'method_one',
             },
         },
         {
-            operation_name => 'broken',
+            operation_name => 'level_one',
             tags           => {
                 'error' => 1,
-                'message' => re(qr/Something wrong/),
+                'message' => re(qr/Inside Die/),
             },
         },
-    ], 'run_method with an embedded span dies with an on_error handler'
+    ], 'CGI::App [WithErrorMode/run_mode_one], dies "Inside Die" at [level_one/inside_die]'
 );
 
 done_testing();

--- a/t/93_error_handling.t
+++ b/t/93_error_handling.t
@@ -3,13 +3,20 @@ use Test::MockObject;
 use Test::OpenTracing::Integration;
 use Test::WWW::Mechanize::CGIApp;
 
+
+
 my $mech = Test::WWW::Mechanize::CGIApp->new();
+
+
 
 lives_ok {
     $mech->app('MyTest::WithErrorBase');
 } "Set Test::WWW::Mechanize app to 'MyTest::WithErrorBase'";
 
+
+
 eval { $mech->get('https://test.tst/test.cgi?rm=run_mode_die') };
+
 global_tracer_cmp_easy(
     [
         {
@@ -38,7 +45,10 @@ global_tracer_cmp_easy(
     ], 'CGI::App [WithErrorBase/run_mode_die], dies "Method Die" at [method_die]'
 );
 
+
+
 eval { $mech->get('https://test.tst/test.cgi?rm=run_mode_one') };
+
 global_tracer_cmp_easy(
     [
         {
@@ -75,7 +85,10 @@ global_tracer_cmp_easy(
     ], 'CGI::App [WithErrorBase/run_mode_one], dies "Inside Die" at [level_one/inside_die]'
 );
 
+
+
 eval { $mech->get('https://test.tst/test.cgi?rm=run_mode_xxx') };
+
 global_tracer_cmp_easy(
     [
         {
@@ -103,11 +116,16 @@ global_tracer_cmp_easy(
     ], 'CGI::App [WithErrorBase/run_mode_xxx] invalid'
 );
 
+
+
 lives_ok {
     $mech->app('MyTest::WithErrorMode');
 } "Set Test::WWW::Mechanize app to 'MyTest::WithErrorMode'";
 
+
+
 $mech->get('https://test.tst/test.cgi?rm=run_mode_die');
+
 global_tracer_cmp_easy(
     [
         {
@@ -132,7 +150,10 @@ global_tracer_cmp_easy(
     ], 'CGI::App [WithErrorMode/run_mode_die], dies "Method Die" at [method_die]'
 );
 
+
+
 $mech->get('https://test.tst/test.cgi?rm=run_mode_one');
+
 global_tracer_cmp_easy(
     [
         {

--- a/t/93_error_handling.t
+++ b/t/93_error_handling.t
@@ -31,18 +31,18 @@ eval { $mech->get('https://test.tst/test.cgi?rm=run_mode_die') };
 global_tracer_cmp_easy(
     [
         {
-            operation_name      => 'cgi_application_request',
-            level               => 0,
-            tags => {
-                'component'        => 'CGI::Application',
-                'http.method'      => 'GET',
-                'http.url'         => 'https://test.tst/test.cgi',
-                'http.query.rm'    => 'run_mode_die',
-                'http.status_code' => 500,
-                'run_mode'         => 'run_mode_die',
-                'run_method'       => 'method_die',
-                'error'            => 1,
-                'message'          => re(qr/Method Die/),
+            operation_name          => 'cgi_application_request',
+            level                   => 0,
+            tags                    => {
+                'component'             => 'CGI::Application',
+                'http.method'           => 'GET',
+                'http.url'              => 'https://test.tst/test.cgi',
+                'http.query.rm'         => 'run_mode_die',
+                'http.status_code'      => 500,
+                'run_mode'              => 'run_mode_die',
+                'run_method'            => 'method_die',
+                'error'                 => 1,
+                'message'               => re(qr/Method Die/),
             },
         },
     ], 'CGI::App [WithErrorBase/run_mode_die], dies "Method Die" at [method_die]'
@@ -52,25 +52,29 @@ eval { $mech->get('https://test.tst/test.cgi?rm=run_mode_one') };
 global_tracer_cmp_easy(
     [
         {
-            operation_name      => 'cgi_application_request',
-            level               => 0,
-            tags => {
-                'component'        => 'CGI::Application',
-                'http.method'      => 'GET',
-                'http.url'         => 'https://test.tst/test.cgi',
-                'http.query.rm'    => 'run_mode_one',
-                'http.status_code' => 500,
-                'run_mode'         => 'run_mode_one',
-                'run_method'       => 'method_one',
-                'error'            => 1,
-                'message'          => re(qr/Inside Die/),
-            },
+            operation_name          => 'cgi_application_request',
+            level                   => 0,
+            tags                    => {
+                'component'             => 'CGI::Application',
+                'http.method'           => 'GET',
+                'http.url'              => 'https://test.tst/test.cgi',
+                'http.query.rm'         => 'run_mode_one',
+                'http.status_code'      => 500,
+                'run_mode'              => 'run_mode_one',
+                'run_method'            => 'method_one',
+                'error'                 => 1,
+                'message'               => re(qr/Inside Die/),
+            },      
         },
         {
             operation_name => 'level_one',
             tags           => {
                 'error' => 1,
                 'message' => re(qr/Inside Die/),
+            operation_name          => 'level_one',
+            tags                    => {
+                'error'                 => 1,
+                'message'               => re(qr/Inside Die/),
             },
         },
     ], 'CGI::App [WithErrorBase/run_mode_one], dies "Inside Die" at [level_one/inside_die]'
@@ -80,17 +84,17 @@ eval { $mech->get('https://test.tst/test.cgi?rm=run_mode_xxx') };
 global_tracer_cmp_easy(
     [
         {
-            operation_name      => 'cgi_application_request',
-            level               => 0,
-            tags => {
-                'component'        => 'CGI::Application',
-                'http.method'      => 'GET',
-                'http.url'         => 'https://test.tst/test.cgi',
-                'http.query.rm'    => 'run_mode_xxx',
-                'http.status_code' => 500,
-                'error'            => 1,
-                'run_mode'         => 'run_mode_xxx',
-                'message'          => re(qr/No such run mode/),
+            operation_name          => 'cgi_application_request',
+            level                   => 0,
+            tags                    => {
+                'component'             => 'CGI::Application',
+                'http.method'           => 'GET',
+                'http.url'              => 'https://test.tst/test.cgi',
+                'http.query.rm'         => 'run_mode_xxx',
+                'http.status_code'      => 500,
+                'error'                 => 1,
+                'run_mode'              => 'run_mode_xxx',
+                'message'               => re(qr/No such run mode/),
             },
         },
     ], 'CGI::App [WithErrorBase/run_mode_xxx] invalid'
@@ -117,17 +121,17 @@ $mech->get('https://test.tst/test.cgi?rm=run_mode_die');
 global_tracer_cmp_easy(
     [
         {
-            operation_name      => 'cgi_application_request',
-            level               => 0,
-            tags                => {
-                'component'           => 'CGI::Application',
-                'http.method'         => 'GET',
-                'http.url'            => 'https://test.tst/test.cgi',
-                'http.query.rm'       => 'run_mode_die',
-                'http.status_code'    => '402',
-                'http.status_message' => "Payment Required",
-                'run_mode'            => 'run_mode_die',
-                'run_method'          => 'method_die',
+            operation_name          => 'cgi_application_request',
+            level                   => 0,
+            tags                    => {
+                'component'             => 'CGI::Application',
+                'http.method'           => 'GET',
+                'http.url'              => 'https://test.tst/test.cgi',
+                'http.query.rm'         => 'run_mode_die',
+                'http.status_code'      => '402',
+                'http.status_message'   => "Payment Required",
+                'run_mode'              => 'run_mode_die',
+                'run_method'            => 'method_die',
             },
         },
     ], 'CGI::App [WithErrorMode/run_mode_die], dies "Method Die" at [method_die]'
@@ -137,24 +141,24 @@ $mech->get('https://test.tst/test.cgi?rm=run_mode_one');
 global_tracer_cmp_easy(
     [
         {
-            operation_name      => 'cgi_application_request',
-            level               => 0,
-            tags                => {
-                'component'           => 'CGI::Application',
-                'http.method'         => 'GET',
-                'http.url'            => 'https://test.tst/test.cgi',
-                'http.query.rm'       => 'run_mode_one',
-                'http.status_code'    => '402',
-                'http.status_message' => "Payment Required",
-                'run_mode'            => 'run_mode_one',
-                'run_method'          => 'method_one',
+            operation_name          => 'cgi_application_request',
+            level                   => 0,
+            tags                    => {
+                'component'             => 'CGI::Application',
+                'http.method'           => 'GET',
+                'http.url'              => 'https://test.tst/test.cgi',
+                'http.query.rm'         => 'run_mode_one',
+                'http.status_code'      => '402',
+                'http.status_message'   => "Payment Required",
+                'run_mode'              => 'run_mode_one',
+                'run_method'            => 'method_one',
             },
         },
         {
-            operation_name => 'level_one',
-            tags           => {
-                'error' => 1,
-                'message' => re(qr/Inside Die/),
+            operation_name          => 'level_one',
+            tags                    => {
+                'error'                 => 1,
+                'message'               => re(qr/Inside Die/),
             },
         },
     ], 'CGI::App [WithErrorMode/run_mode_one], dies "Inside Die" at [level_one/inside_die]'


### PR DESCRIPTION
The `error_handling` test could be improved.

The enhanced tests are passing, based on the current behaviour. But we will need to change the behaviour of euro handling, to work according a proposal on an other issue.