### PR TITLE
Extract incoming SpanContext from HTTP headers

### DIFF
--- a/lib/CGI/Application/Plugin/OpenTracing.pm
+++ b/lib/CGI/Application/Plugin/OpenTracing.pm
@@ -385,17 +385,6 @@ sub _cgi_get_run_method {
 }
 
 
-
-# TODO: extract headers from CGI request
-#
-sub _cgi_get_http_headers {
-    my $cgi_app = shift;
-    
-    return HTTP::Headers->new();
-}
-
-
-
 sub _cgi_get_header_status {
     my $cgi_app = shift;
 
@@ -430,6 +419,13 @@ sub _cgi_get_query_http_method {
 }
 
 
+sub _cgi_get_http_headers {
+    my $cgi_app = shift;
+
+    my $query = $cgi_app->query();
+
+    HTTP::Headers->new(map { s/^HTTP_//r => $query->http($_) } $query->http);
+}
 
 sub _cgi_get_query_http_url {
     my $cgi_app = shift;

--- a/t/94_headers.t
+++ b/t/94_headers.t
@@ -1,0 +1,35 @@
+use Test::Most;
+use Test::MockObject;
+use Test::OpenTracing::Integration;
+use Test::WWW::Mechanize::CGIApp;
+
+my $mech = Test::WWW::Mechanize::CGIApp->new;
+$mech->app('MyTest::CGI::Application');
+
+$mech->get('https://test.tst/test.cgi',
+    'OpenTracing-Trace-Id' => 1234,
+    'OpenTracing-Span-Id'  => 1111,
+);
+global_tracer_cmp_easy([
+    {
+        trace_id => 1234,
+    },
+], "trace_id inherited from headers");
+done_testing();
+
+
+
+package MyTest::CGI::Application;
+
+use base 'CGI::Application';
+
+use CGI::Application::Plugin::OpenTracing qw/Test/;
+use OpenTracing::GlobalTracer qw/$TRACER/;
+
+sub run_modes {
+    start => 'foo',
+}
+
+sub foo { return }
+
+1;


### PR DESCRIPTION
Generate a HTTP::Headers object from the CGI query and pass it to tracer->extract so that tracers have access to headers